### PR TITLE
add globals: ls, dir, tostring, scoresub, _pausemenu

### DIFF
--- a/pico_process.py
+++ b/pico_process.py
@@ -9,7 +9,7 @@ main_globals = {
     "costatus", "count", "cstore", "cursor", "del", "deli",
     "dget", "dset", "extcmd", "fget", "fillp", "flip",
     "flr", "foreach", "fset", "getmetatable", "ipairs", "inext",
-    "line", "load", "map", "max", "memcpy", "memset",
+    "line", "load", "ls", "map", "max", "memcpy", "memset",
     "menuitem", "mget", "mid", "min", "mset", "music",
     "next", "ord", "oval", "ovalfill", "pack", "pairs",
     "pal", "palt", "peek", "peek2", "peek4", "pget",
@@ -31,7 +31,7 @@ deprecated_globals = {
 undocumented_globals = {
     "holdframe", "_set_fps", "_update_buttons",
     "_map_display", "_get_menu_item_selected",
-    "set_draw_slice",
+    "set_draw_slice", "tostring",
 }
 
 pattern_globals = set(chr(ch) for ch in range(0x80, 0x9a))


### PR DESCRIPTION
tostring() works in pico8 (0.2.5g). It seems like an oversight but shrinko8 should not rename it; it's very easy to accidentally use tostring() instead of tostr(), which creates errors like "attempt to call global 'ol' (a nil value)" after running through shrinko8

after fixing this, I checked to see if there were any other globals: `for k,v in all(_𝘦𝘯𝘷) do printh(k.." : "..tostr(v)) end`

I added a few (ls, etc) but also found a bunch more; I'm not sure if these should be added or not:

> __flip : [function]
> __trace : [function]
> __type : [function]
> _end_of_program : 1
> _mark_cpu : [function]
> _menuitem : [function]
> _set_mainloop_exists : [function]
> _startframe : [function]
> _update_framerate : [function]
> backup : [function]
> bbsreq : [function]
> cd : [function]
> exit : [function]
> export : [function]
> folder : [function]
> help : [function]
> import : [function]
> info : [function]
> install_demos : [function]
> install_games : [function]
> keyconfig : [function]
> login : [function]
> logout : [function]
> mkdir : [function]
> radio : [function]
> reboot : [function]
> reset : [function]
> save : [function]
> shutdown : [function]
> splore : [function]

(most of them seem useless / nonfunctional from within a cart, but they also don't throw errors, and if shrinko8 renames them then they'll throw nil function errors... but they also don't seem to fit the names "deprecated_globals" or "undocumented_globals")