### PR TITLE
add global: reset

### DIFF
--- a/pico_process.py
+++ b/pico_process.py
@@ -4,7 +4,7 @@ from pico_compress import print_size
 from pico_preprocess import k_tab_break
 
 # when adding new globals:
-#   check whether to update builtins_copied_to_locals (find 'local ...=...' script inside pico8 binary)
+#   check whether to update builtins_copied_to_locals (find 'local ...=...' script inside pico8 binary; e.g. `strings $(which pico8) | grep "^local "`)
 #   consider whether to update builtins_with_callbacks
 
 main_builtins = {
@@ -20,7 +20,7 @@ main_builtins = {
     "pal", "palt", "peek", "peek2", "peek4", "pget",
     "poke", "poke2", "poke4", "print", "printh", "pset",
     "rawequal", "rawget", "rawlen", "rawset", "rect",
-    "rectfill", "reload", "rnd", "run", "select", "setmetatable",
+    "rectfill", "reload", "reset", "rnd", "run", "select", "setmetatable",
     "serial", "sfx", "sget", "sgn", "sin", "split",
     "spr", "sqrt", "srand", "sset", "sspr", "stat", "stop",
     "sub", "time", "tline", "tonum", "tostr", "trace", "type",
@@ -46,7 +46,11 @@ builtins_copied_to_locals = { # builtins listed here should also be listed elsew
     "del", "deli", "clip", "color", "pal", "palt", "fillp",
     "pget", "pset", "sget", "sset", "fget", "fset",
     "circ", "circfill", "rect", "rectfill", "oval", "ovalfill",
-    "line", "spr", "sspr"
+    "line", "spr", "sspr",
+    "mget", "mset", "tline", "peek", "poke", "peek2", "poke2",
+    "peek4", "poke4", "memcpy", "memset", "max", "min", "mid",
+    "flr", "ceil", "cos", "sin", "atan2", "srand", "band",       # note: rnd is missing due to a pico8 typo
+    "bor", "bxor", "bnot", "shl", "shr", "lshr", "rotl", "rotr",
 }
 
 builtins_with_callbacks = { # builtins listed here may call user code before returning, NOT including far-fetched stuff like metamethods

--- a/test_compare/bad-tab.txt
+++ b/test_compare/bad-tab.txt
@@ -7,7 +7,7 @@ test_input/bad.p8 (tab 0, line 6, col 6): Identifier 'y' not found - did you mea
 test_input/bad.p8 (tab 0, line 6, col 9): Built-in global 't' assigned outside _init - did you mean to use 'local'?
 test_input/bad.p8 (tab 0, line 7, col 12): Identifier 'f1' not found - did you mean to use 'local function' to define it?
 test_input/bad.p8 (tab 0, line 8, col 18): Local 'f12' isn't used
-test_input/bad.p8 (tab 0, line 15, col 12): Built-in global 'band' assigned outside _init - did you mean to use 'local function'?
+test_input/bad.p8 (tab 0, line 15, col 12): Built-in global 'abs' assigned outside _init - did you mean to use 'local function'?
 test_input/bad.p8 (tab 1, line 4, col 9): Local 'a' isn't used
 test_input/bad.p8 (tab 1, line 4, col 12): Local 'b' is only ever assigned to, never used
 test_input/bad.p8 (tab 1, line 8, col 13): Local 'd' is only ever assigned to, never used

--- a/test_compare/bad.txt
+++ b/test_compare/bad.txt
@@ -7,7 +7,7 @@ test_input/bad.p8:6:6: Identifier 'y' not found - did you mean to use 'local' to
 test_input/bad.p8:6:9: Built-in global 't' assigned outside _init - did you mean to use 'local'?
 test_input/bad.p8:7:12: Identifier 'f1' not found - did you mean to use 'local function' to define it?
 test_input/bad.p8:8:18: Local 'f12' isn't used
-test_input/bad.p8:15:12: Built-in global 'band' assigned outside _init - did you mean to use 'local function'?
+test_input/bad.p8:15:12: Built-in global 'abs' assigned outside _init - did you mean to use 'local function'?
 test_input/bad.p8:22:9: Local 'a' isn't used
 test_input/bad.p8:22:12: Local 'b' is only ever assigned to, never used
 test_input/bad.p8:26:13: Local 'd' is only ever assigned to, never used

--- a/test_compare/badcount.txt
+++ b/test_compare/badcount.txt
@@ -1,3 +1,3 @@
 tokens: 162 2%
-chars: 1064 2%
-compressed: 451 3%
+chars: 1063 2%
+compressed: 452 3%

--- a/test_input/bad.p8
+++ b/test_input/bad.p8
@@ -12,10 +12,10 @@ function f2()
   return t(line)
 end
 function f2d1()
-  function band() end
+  function abs() end
 end
-local this_is_ok = bor
-function bor() return this_is_ok() end
+local this_is_ok = sgn
+function sgn() return this_is_ok() end
 -->8
 -- unused
 function fx()


### PR DESCRIPTION
I just ran into this -- I used reset() in a cart and that confused shrinko8 (see `help reset`; it reloads 0x5f00..0x5f7f)

also, I filled out builtins_copied_to_locals (copied from pico8 0.2.5g for linux)