### PR TITLE
fix compressed count regression

### DIFF
--- a/shrinko8.py
+++ b/shrinko8.py
@@ -387,7 +387,7 @@ def handle_processing(args, main_cart, extra_carts):
         
         if args.count:
             write_code_size(cart, handler=args.count)
-            if not (args.output and args.format.is_src()) and not args.no_count_compress: # else, will be done in write_cart
+            if not (args.output and not args.format.is_src()) and not args.no_count_compress: # else, will be done in write_cart
                 write_compressed_size(cart, handler=args.count, fast_compress=args.fast_compression, debug_handler=args.trace_compression)
         
         if args.version:


### PR DESCRIPTION
repro: `echo 'abc=3' | shrinko8 --count --minify - -`

before this commit, this command showed stats for
tokens and chars, but not compressed

now, it also shows compressed

---

sometime between 15304dad9938fa138b9716c9f9ddc9c323ad686d and now, the code changed:
```py
# 15304da
if not (args.output and str(args.format) not in CartFormat.src_names) and not args.no_count_compress: # else, will be done in write_cart

# before this commit
if not (args.output and args.format.is_src()) and not args.no_count_compress: # else, will be done in write_cart
```

The difference is `str(args.format) not in CartFormat.src_names` -> `args.format.is_src()`, which is missing a `not`. fixed!