### PR TITLE
Generate tiny ROMs for Picotron

### DIFF
--- a/picotron_cart.py
+++ b/picotron_cart.py
@@ -20,7 +20,7 @@ class Cart64Format(Enum):
         return m != m.auto
     @property
     def is_ext(m):
-        return m not in (m.auto, m.dir, m.fs, m.label)
+        return m not in (m.auto, m.dir, m.fs, m.label, m.tiny_rom)
     @property
     def is_src(m):
         return m in (m.p64, m.lua, m.dir, m.fs)

--- a/site/index.html
+++ b/site/index.html
@@ -225,6 +225,7 @@ It can be a .{{srcext}} file, a .png cart, {{"a whole directory, " if picotron}}
                 <option value="dir">Directory (Zipped)</option>
                 <option value="" disabled>──────────</option>
                 <option value="lua">main.lua file (Main code only)</option>
+                <option value="tiny-rom">Tiny .ROM file (Main code only)</option>
                 {% endif %}
               </select>
             </label>

--- a/site/index.js
+++ b/site/index.js
@@ -619,7 +619,7 @@ async function doMinify() {
         }
 
         // (adjust p8 preview)
-        if (format === "tiny-rom") {
+        if (isPico8 && format === "tiny-rom") {
             args.push("--output-sections", "lua");
         } else if (format === "url") {
             args.push("--output-sections", "lua,gfx");


### PR DESCRIPTION
Add support for generating tiny ROMs for Picotron. main.lua only, metadata stripped, tries all 3 of standard-LZ4-compressed-cart (w/ main.lua only), PXA, and raw, and picks the smallest. I'd imagine that'll usually be PXA, but I don't think it hurts?

I have not tested the changes in `site/`, but the tiny output I have smoke tested (in all 3 formats).

See also: https://mastodon.social/@zep/113026379899290998 , and the reply clarifying that he meant PXA.