### PR TITLE
add some NodeType.block ignore-keys for debug printing

### DIFF
--- a/pico_tokenize.py
+++ b/pico_tokenize.py
@@ -38,7 +38,7 @@ class TokenNodeBase:
         reprlist = []
         for key, val in m.__dict__.items():
             if key in ("parent", "children", "idx", "endidx", "vline", "lang", "modified", "source",
-                       "scope", "extra_i", "extra_children"):
+                       "scope", "extra_i", "extra_children", "stmts", "globals", "members"):
                 continue
             reprlist.append("%s=%r" % (key, val))
         return "%s(%s)" % (typename(m), ", ".join(reprlist))


### PR DESCRIPTION
thanks for #42! I ran my [custom linter](https://github.com/thisismypassport/shrinko8/issues/41#issuecomment-2283978982) with `print(node)` and got 50+ lines of noise from NodeType.block nodes, so here's a small edit that prevents that

before:
```
Node(type=NodeType.block, stmts=[Node(type=call), Node(type=function), Node(type=function), Node(type=local), Node(type=call), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=assign), Node(type=function), Node(type=function), Node(type=assign), Node(type=function), Node(type=function), Node(type=function), Node(type=assign), Node(type=assign), Node(type=call), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=function), Node(type=assign), Node(type=function), Node(type=function),
  ... (many more here) ...
  , Node(type=function), Node(type=function), Node(type=assign), Node(type=function), Node(type=function)], globals=LazyDict(None, {'printh': Global(printh), 'dev': Global(dev), 'dev_seed': Global(dev_seed), 'dev_unlockall': Global(dev_unlockall), 'dev_wipesave': Global(dev_wipesave), 'dev_skiptitle': Global(dev_skiptitle), 'dev_mousecopy': Global(dev_mousecopy), 'dev_fullsummary': Global(dev_fullsummary), 'dev_rmb_score': Global(dev_rmb_score), 'dev_logevents': Global(dev_logevents), 'dev_stats': Global(dev_stats), 'pq': Global(pq), 'qjoin': Global(qjoin), 'qq': Global(qq), 'select': Global(select), '_quote': Global(_quote), 'type': Global(type), 'next': Global(next), 'pqx': Global(pqx), 'pqn': Global(pqn), 'toast': Global(toast)
  ... (many more here) ...
```

after:
```
Node(type=NodeType.block, has_env=True)
```