### PR TITLE
Add support for tab indentation in unminifier

### DIFF
--- a/pico_unminify.py
+++ b/pico_unminify.py
@@ -4,6 +4,7 @@ from pico_parse import NodeType, is_function_stmt, is_short_block_stmt
 
 def unminify_code(root, unminify_opts):    
     indent_delta = unminify_opts.get("indent", 2)
+    indent_delta = indent_delta if indent_delta == "\t" else " " * indent_delta
 
     output = []
     prev_token = Token.none
@@ -24,11 +25,11 @@ def unminify_code(root, unminify_opts):
             if "\n" in comment_value:
                 if prev_tight:
                     output.append("\n")
-                    output.append(" " * indent)
+                    output.append(indent_delta * indent)
                 output.append(comment_value)
                 if not comment_value.endswith("\n"):
                     output.append("\n")
-                output.append(" " * indent)
+                output.append(indent_delta * indent)
             else:
                 if prev_tight and prev_token.value not in k_tight_prefix_tokens:
                     output.append(" ")
@@ -67,7 +68,7 @@ def unminify_code(root, unminify_opts):
 
         if node.type == NodeType.block:
             if node.parent:
-                indent += indent_delta
+                indent += 1
                 # shorthand -> longhand
                 if is_short_block_stmt(node.parent) and node.parent.type != NodeType.else_:
                     output.append(" then" if node.parent.type == NodeType.if_ else " do")
@@ -84,7 +85,7 @@ def unminify_code(root, unminify_opts):
                     output.append("\n")
 
             curr_stmt = node
-            output.append(" " * indent)
+            output.append(indent_delta * indent)
             prev_tight = False
 
     def end_visit_node(node):
@@ -92,10 +93,10 @@ def unminify_code(root, unminify_opts):
 
         if node.type == NodeType.block:
             if node.parent:
-                indent -= indent_delta
+                indent -= 1
 
             curr_stmt = stmt_stack.pop()
-            output.append(" " * indent)
+            output.append(indent_delta * indent)
             prev_tight = False
             
             # shorthand -> longhand

--- a/shrinko.py
+++ b/shrinko.py
@@ -157,7 +157,8 @@ def create_main(lang):
 
         pgroup = parser.add_argument_group("unminify options")
         pgroup.add_argument("--unminify", action="store_true", help="enable unminification of the cart")
-        pgroup.add_argument("--unminify-indent", type=int, help="indentation size when unminifying", default=2)
+        pgroup.add_argument("--unminify-indent", type=lambda s: "\t" if s == "tabs" else int(s),
+                            help="indentation size when unminifying", default=2)
 
         pgroup = parser.add_argument_group("misc. options")
         pgroup.add_argument("-s", "--script", action="append", help="manipulate the cart via a custom python script - see README for api details")


### PR DESCRIPTION
The proposed change to the `--unminify-indent` option supports "tabs" for tab indentation, or an integer representing the number of spaces per level of indentation.