### PR TITLE
fix: prevent merging --keep: comments with surrounding lines

### DIFF
--- a/pico_output.py
+++ b/pico_output.py
@@ -297,19 +297,31 @@ def output_node(root, ctxt, minify_wspace=True, minify_lines=True, exclude_comme
         if token.children:
             for comment in token.children:
                 if comment.hint == CommentHint.keep:
-                    output.append(comment.value.replace(k_keep_prefix, "", 1))
+                    if need_linebreak or (not minify_lines and comment.vline != prev_vline):
+                        output.append("\n")
+                        need_linebreak = False
+                    
+                    val = comment.value.replace(k_keep_prefix, "", 1)
+                    if val.endswith("\n"):
+                        val = val[:-1]
+                        if val.endswith("\r"):
+                            val = val[:-1]
+                        need_linebreak = True
+
+                    output.append(val)
+                    prev_vline = comment.vline
 
         if token.value is None:
             return
 
         # (modified tokens may require whitespace not previously required - e.g. 0b/0x)
-        if (prev_token.endidx < token.idx or prev_token.modified or token.modified) and prev_token.value:
+        if need_linebreak or ((prev_token.endidx < token.idx or prev_token.modified or token.modified) and prev_token.value):
             # TODO: can we systemtically add whitespace to imrpove compression? (failed so far)
 
             if need_linebreak or (not minify_lines and token.vline != prev_vline):
                 output.append("\n")
                 need_linebreak = False
-            elif need_whitespace_between(ctxt, prev_token, token):
+            elif prev_token.value and need_whitespace_between(ctxt, prev_token, token):
                 output.append(" ")
 
         output.append(token.value)

--- a/pico_tokenize.py
+++ b/pico_tokenize.py
@@ -267,9 +267,9 @@ class CommentHint(Enum):
 class Comment(TokenNodeBase):
     """A pico8 comment, optionally holding some kind of hint"""
 
-    def __init__(m, hint, hintdata=None, source=None, idx=None, endidx=None):
+    def __init__(m, hint, hintdata=None, source=None, idx=None, endidx=None, vline=None):
         super().__init__()
-        m.hint, m.hintdata, m.source, m.idx, m.endidx = hint, hintdata, source, idx, endidx
+        m.hint, m.hintdata, m.source, m.idx, m.endidx, m.vline = hint, hintdata, source, idx, endidx, vline
 
     @property
     def value(m):
@@ -388,7 +388,7 @@ def tokenize(source, ctxt=None, all_comments=False, lang=None):
         if mods.sublang != None:
             add_sublang(token, mods.sublang)
 
-    def process_comment(orig_idx, comment, isblock):
+    def process_comment(orig_idx, comment, isblock, vline):
         hint, hintdata = CommentHint.none, None
 
         if process_hints:
@@ -443,15 +443,16 @@ def tokenize(source, ctxt=None, all_comments=False, lang=None):
                     hint = CommentHint.none
         
         if all_comments or (hint != CommentHint.none and hint != CommentHint.auto):
-            get_next_mods().add_comment(Comment(hint, hintdata, source, orig_idx, idx))
+            get_next_mods().add_comment(Comment(hint, hintdata, source, orig_idx, idx, vline))
 
     def tokenize_line_comment():
         nonlocal vline
         orig_idx = idx
+        comment_vline = vline
         while take() not in ('\n', ''): pass
         vline += 1
 
-        process_comment(orig_idx - 2, text[orig_idx:idx], isblock=False)
+        process_comment(orig_idx - 2, text[orig_idx:idx], isblock=False, vline=comment_vline)
 
     def tokenize_long_brackets(off):
         nonlocal idx
@@ -475,10 +476,12 @@ def tokenize(source, ctxt=None, all_comments=False, lang=None):
         return False, orig_idx, None, None
 
     def tokenize_long_comment():
-        nonlocal idx
+        nonlocal idx, vline
         ok, orig_idx, start, end = tokenize_long_brackets(0)
         if ok:
-            process_comment(orig_idx - 2, text[start:end], isblock=True)
+            comment_vline = vline
+            vline += text.count("\n", start, end)
+            process_comment(orig_idx - 2, text[start:end], isblock=True, vline=comment_vline)
         else:
             idx = orig_idx
         return ok

--- a/run_tests.py
+++ b/run_tests.py
@@ -280,6 +280,7 @@ def run():
     run_test("short-spaces", "short.p8", "short-spaces.p8", "-m", "--no-minify-consts", "--no-minify-spaces", "--focus-chars", pico8_output_val="K\nK")
     run_test("short2", "short2.p8", "short2.p8", "-m", "--no-minify-consts", "--focus-compressed", "--no-minify-spaces")
     run_test("comment", "comment.lua", "comment.lua", "-m")
+    run_test("keep_comment", "keep_comment.p8", "keep_comment.p8", "--minify", "--no-minify-lines")
 
     run_test("version-latest", "versioned.p8", "versioned-latest.p8", "-m", "-oc", pico8_output="versioned.p8.printh")
     run_test("version-orig", "versioned.p8", "versioned-orig.p8", "-m", "-oc", update_version=False, pico8_output="versioned.p8.printh")

--- a/test_compare/keep_comment.p8
+++ b/test_compare/keep_comment.p8
@@ -1,0 +1,9 @@
+pico-8 cartridge // http://www.pico-8.com
+version 42
+__lua__
+function _init()
+n=1
+-- comment 1
+-- comment 2
+f=2
+end

--- a/test_input/keep_comment.p8
+++ b/test_input/keep_comment.p8
@@ -1,0 +1,9 @@
+pico-8 cartridge // http://www.pico-8.com
+version 16
+__lua__
+function _init()
+  x=1
+  --keep: comment 1
+  --keep: comment 2
+  y=2
+end


### PR DESCRIPTION
Fixes a bug where preserved comments were being merged with previous or next lines when using --minify and --no-minify-lines.

- Store line numbers in Comment objects in the tokenizer
- Update output generator to respect line breaks for preserved comments
- Added a new test case to verify the fix